### PR TITLE
Add support for yaml & json tmLanguage files

### DIFF
--- a/lib/sublime_syntax_convertor/convertor.rb
+++ b/lib/sublime_syntax_convertor/convertor.rb
@@ -1,3 +1,5 @@
+require "yaml"
+
 module SublimeSyntaxConvertor
   class Convertor
     include Formatter
@@ -5,6 +7,9 @@ module SublimeSyntaxConvertor
 
     def initialize(lang)
       @lang       = Plist.parse_xml(lang)
+      if @lang.nil?
+        @lang = YAML.load(lang)
+      end
       @repository = @lang.fetch('repository', {})
       @patterns   = @lang.fetch('patterns', [])
       @syntax     = {}


### PR DESCRIPTION
[VSCode allows tmLanguage files written in JSON instead of XML Plists](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#tokenization), and I believe it would be useful to have that capability here, as a lot of people will start adding IDE support for their language with a VSCode extension, as [it is the most popular code editor right now](https://www.software.com/src/ranking-the-top-5-code-editors-2019).<sup>this source dates back to 2019 but it's quite safe to assume it still is the case in 2022</sup>

The change does not require any new dependency, as yaml support is built-in, and is a 3-line-change.

(Note that supporting YAML gives us JSON support for free, since the former is a superset of the latter)
